### PR TITLE
Add template flag

### DIFF
--- a/cmd/codescanning.go
+++ b/cmd/codescanning.go
@@ -26,7 +26,6 @@ func init() {
 	codeScanningCmd.PersistentFlags().StringVarP(&WorkflowFile, "workflow", "w", "", "specify the path to the code scanning workflow file")
 	codeScanningCmd.PersistentFlags().StringVarP(&TemplateFile, "template", "t", "", "specify the path to the code scanning workflow template file")
 	codeScanningCmd.MarkFlagsMutuallyExclusive("workflow", "template")
-	// codeScanningCmd.MarkPersistentFlagRequired("workflow")
 	codeScanningCmd.PersistentFlags().StringVarP(&LogFile, "log", "l", "gh-add-files.log", "specify the path where the log file will be saved")
 	// MarkFlagsOneRequired is only available in cobra v1.8.0 that still isn't released yet (https://github.com/spf13/cobra/issues/1936#issuecomment-1669126066)
 	// codeScanningCmd.MarkFlagsOneRequired("csv", "organization")

--- a/cmd/codescanning.go
+++ b/cmd/codescanning.go
@@ -14,20 +14,24 @@ import (
 var Organization string
 var WorkflowFile string
 var LogFile string
-
+var TemplateFile string
 var Branch string
 var CsvFile string
 var Errors = make(map[string]error)
 
 func init() {
 	codeScanningCmd.PersistentFlags().StringVarP(&Organization, "organization", "o", "", "specify Organisation to implement code scanning")
-	codeScanningCmd.PersistentFlags().StringVarP(&WorkflowFile, "workflow", "w", "", "specify the path to the code scanning workflow file")
-	codeScanningCmd.MarkPersistentFlagRequired("workflow")
-	codeScanningCmd.PersistentFlags().StringVarP(&LogFile, "log", "l", "gh-add-files.log", "specify the path where the log file will be saved")
 	codeScanningCmd.PersistentFlags().StringVarP(&CsvFile, "csv", "c", "", "specify the location of csv file")
+	codeScanningCmd.MarkFlagsMutuallyExclusive("csv", "organization")
+	codeScanningCmd.PersistentFlags().StringVarP(&WorkflowFile, "workflow", "w", "", "specify the path to the code scanning workflow file")
+	codeScanningCmd.PersistentFlags().StringVarP(&TemplateFile, "template", "t", "", "specify the path to the code scanning workflow template file")
+	codeScanningCmd.MarkFlagsMutuallyExclusive("workflow", "template")
+	// codeScanningCmd.MarkPersistentFlagRequired("workflow")
+	codeScanningCmd.PersistentFlags().StringVarP(&LogFile, "log", "l", "gh-add-files.log", "specify the path where the log file will be saved")
 	// MarkFlagsOneRequired is only available in cobra v1.8.0 that still isn't released yet (https://github.com/spf13/cobra/issues/1936#issuecomment-1669126066)
 	// codeScanningCmd.MarkFlagsOneRequired("csv", "organization")
-	codeScanningCmd.MarkFlagsMutuallyExclusive("csv", "organization")
+	// codeScanningCmd.MarkFlagsOneRequired("workflow", "template")
+	
 }
 
 var codeScanningCmd = &cobra.Command{
@@ -58,6 +62,13 @@ var codeScanningCmd = &cobra.Command{
 			log.Fatalln("ERROR: You cannot provide both organization flag and repository names as arguments")
 		} else if len(CsvFile) > 0 && len(args) > 0 {
 			log.Fatalln("ERROR: You cannot provide both csv flag and repository names as arguments")
+		}
+
+		// check if workflow or template file is provided
+		if len(WorkflowFile) <= 0 && len(TemplateFile) <= 0 {
+			log.Fatalln("ERROR: Either workflow flag or template flag must be provided")
+		} else if len(WorkflowFile) > 0 && len(TemplateFile) > 0 {
+			log.Fatalln("ERROR: You cannot provide both workflow flag and template flag")
 		}
 
 		var repos []Repository
@@ -168,7 +179,22 @@ var codeScanningCmd = &cobra.Command{
 			}
 			log.Printf("Ref created succesfully at : %s\n", newbranchref)
 			
-			createdFile, err := repo.createWorkflowFile(WorkflowFile)
+			var workflowFile []byte
+			if len(TemplateFile) > 0 {
+				workflowFile, err = repo.generateCodeqlWorkflowFile(TemplateFile)
+				if err != nil {
+					Errors[repo.FullName] = err
+					continue
+				}
+			} else {
+				workflowFile, err = repo.readCodeqlWorkflowFile(WorkflowFile)
+				if err != nil {
+					Errors[repo.FullName] = err
+					continue
+				}
+			}
+
+			createdFile, err := repo.commitWorkflowFile(workflowFile)
 			if err != nil {
 				log.Println(err)
 				continue

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -283,22 +283,58 @@ func (repo *Repository) doesCodeqlWorkflowExist() (bool, error) {
 	}
 }
 
-func (repo *Repository) createWorkflowFile(WorkflowFile string) (string, error) {
-
+func (repo *Repository) readCodeqlWorkflowFile(WorkflowFile string) ([]byte, error) {
 	//Open file on disk
 	f, err := os.Open(WorkflowFile)
 	if err != nil {
 		log.Println(err)
-		return "", err
+		return []byte{}, err
 	}
 	reader := bufio.NewReader(f)
 	content, err := io.ReadAll(reader)
 	if err != nil {
 		log.Println(err)
-		return "", err
+		return []byte{}, err
 	}
 
-	encoded := base64.StdEncoding.EncodeToString((content))
+	return content, nil
+}
+
+func (repo *Repository) generateCodeqlWorkflowFile(TemplateWorkflowFile string) ([]byte, error) {
+	//Open file on disk
+	f, err := os.Open(TemplateWorkflowFile)
+	if err != nil {
+		log.Printf("ERROR: Unable to open template workflow file %s\n", TemplateWorkflowFile)
+		return []byte{}, err
+	}
+	reader := bufio.NewReader(f)
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		log.Printf("ERROR: Unable to read template workflow file %s\n", TemplateWorkflowFile)
+		return []byte{}, err
+	}
+
+	//replace repo name
+	workflowFile := strings.ReplaceAll(string(content), "{{ .DefaultBranch }}", repo.DefaultBranch)
+	return []byte(workflowFile), nil
+}
+
+func (repo *Repository) commitWorkflowFile(WorkflowFile []byte) (string, error) {
+
+	//Open file on disk
+	// f, err := os.Open(WorkflowFile)
+	// if err != nil {
+	// 	log.Println(err)
+	// 	return "", err
+	// }
+	// reader := bufio.NewReader(f)
+	// content, err := io.ReadAll(reader)
+	// if err != nil {
+	// 	log.Println(err)
+	// 	return "", err
+	// }
+
+	encoded := base64.StdEncoding.EncodeToString((WorkflowFile))
 
 	type Commiter struct {
 		Name  string `json:"name"`

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -355,20 +355,6 @@ func (repo *Repository) generateCodeqlWorkflowFile(TemplateWorkflowFile string) 
 }
 
 func (repo *Repository) commitWorkflowFile(WorkflowFile []byte, commitSha string) (string, error) {
-
-	//Open file on disk
-	// f, err := os.Open(WorkflowFile)
-	// if err != nil {
-	// 	log.Println(err)
-	// 	return "", err
-	// }
-	// reader := bufio.NewReader(f)
-	// content, err := io.ReadAll(reader)
-	// if err != nil {
-	// 	log.Println(err)
-	// 	return "", err
-	// }
-
 	encoded := base64.StdEncoding.EncodeToString((WorkflowFile))
 
 	type Commiter struct {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -55,6 +55,11 @@ func Test_getRepos(t *testing.T) {
 					Name:          "titanforest",
 					DefaultBranch: "main",
 				},
+				{
+					FullName:      "paradisisland/shiganshima",
+					Name:          "shiganshima",
+					DefaultBranch: "main",
+				},
 			},
 			wantErr: false,
 		},
@@ -443,8 +448,6 @@ func TestRepository_checkDefaultSetupEnabled(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
-
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -611,7 +614,7 @@ func TestRepository_doesCodeqlWorkflowExist(t *testing.T) {
 	}
 }
 
-func TestRepository_createWorkflowFile(t *testing.T) {
+func TestRepository_readCodeqlWorkflowFile(t *testing.T) {
 	type fields struct {
 		FullName      string
 		Name          string
@@ -619,6 +622,178 @@ func TestRepository_createWorkflowFile(t *testing.T) {
 	}
 	type args struct {
 		WorkflowFile string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		// Write test cases for the following scenarios:
+		// 1. When a codeql workflow file is provided and is valid
+		// 2. When a codeql workflow file is provided and is invalid
+		// 3. When a codeql workflow file is not provided
+
+		// Test case 1
+		{
+			name: "When a codeql workflow file is provided and is valid",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "main",
+			},
+			args: args{
+				WorkflowFile: "../examples/codeql.yml",
+			},
+			want:    []byte("name: CodeQL \non:\n  push:\n    branches: [ \"main\" ]\n  pull_request:\n    branches: [ \"main\" ]\n  workflow_dispatch:\n\njobs:\n code_analysis:\n   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main\n"),
+			wantErr: false,
+		},
+
+		// Test case 2
+		{
+			name: "When a codeql workflow file is provided and is invalid",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "main",
+			},
+			args: args{
+				WorkflowFile: "../examples/codeql_invalid.yml",
+			},
+			want:    []byte(""),
+			wantErr: true,
+		},
+
+		// Test case 3
+		{
+			name: "When a codeql workflow file is not provided",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "main",
+			},
+			args: args{
+				WorkflowFile: "",
+			},
+			want:    []byte(""),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &Repository{
+				FullName:      tt.fields.FullName,
+				Name:          tt.fields.Name,
+				DefaultBranch: tt.fields.DefaultBranch,
+			}
+			got, err := repo.readCodeqlWorkflowFile(tt.args.WorkflowFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Repository.readCodeqlWorkflowFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Repository.readCodeqlWorkflowFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepository_generateCodeqlWorkflowFile(t *testing.T) {
+	type fields struct {
+		FullName      string
+		Name          string
+		DefaultBranch string
+	}
+	type args struct {
+		TemplateWorkflowFile string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		// Write test cases for the following scenarios:
+		// 1. When a template workflow file is provided and is valid
+		// 2. When a template workflow file is provided and is invalid
+		// 3. When a template workflow file is not provided
+
+		// Test case 1
+		{
+			name: "When a template workflow file is provided and is valid",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "totallyuniquebranchname",
+			},
+			args: args{
+				TemplateWorkflowFile: "../examples/codeql-template.yml",
+			},
+			want:    []byte("name: CodeQL \non:\n  push:\n    branches: [ \"totallyuniquebranchname\" ]\n  pull_request:\n    branches: [ \"totallyuniquebranchname\" ]\n  workflow_dispatch:\n\njobs:\n code_analysis:\n   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main\n"),
+			wantErr: false,
+		},
+
+		// Test case 2
+		{
+			name: "When a template workflow file is provided and is invalid",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "main",
+			},
+			args: args{
+				TemplateWorkflowFile: "../examples/codeql-template-invalid.yml",
+			},
+			want:    []byte(""),
+			wantErr: true,
+		},
+
+		// Test case 3
+		{
+			name: "When a template workflow file is not provided",
+			fields: fields{
+				FullName:      "paradisisland/maria",
+				Name:          "maria",
+				DefaultBranch: "main",
+			},
+			args: args{
+				TemplateWorkflowFile: "",
+			},
+			want:    []byte(""),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &Repository{
+				FullName:      tt.fields.FullName,
+				Name:          tt.fields.Name,
+				DefaultBranch: tt.fields.DefaultBranch,
+			}
+			got, err := repo.generateCodeqlWorkflowFile(tt.args.TemplateWorkflowFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Repository.generateCodeqlWorkflowFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Repository.generateCodeqlWorkflowFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepository_commitWorkflowFile(t *testing.T) {
+	type fields struct {
+		FullName      string
+		Name          string
+		DefaultBranch string
+	}
+	type args struct {
+		WorkflowFile []byte
 	}
 	tests := []struct {
 		name    string
@@ -642,7 +817,7 @@ func TestRepository_createWorkflowFile(t *testing.T) {
 				DefaultBranch: "main",
 			},
 			args: args{
-				WorkflowFile: "../examples/codeql.yml",
+				WorkflowFile: []byte("name: CodeQL \non:\n  push:\n    branches: [ \"main\" ]\n  pull_request:\n    branches: [ \"main\" ]\n  workflow_dispatch:\n\njobs:\n code_analysis:\n   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main\n"),
 			},
 			want:    "codeql.yml",
 			wantErr: false,
@@ -657,7 +832,7 @@ func TestRepository_createWorkflowFile(t *testing.T) {
 				DefaultBranch: "main",
 			},
 			args: args{
-				WorkflowFile: "../examples/codeql.yml",
+				WorkflowFile: []byte("name: CodeQL \non:\n  push:\n    branches: [ \"main\" ]\n  pull_request:\n    branches: [ \"main\" ]\n  workflow_dispatch:\n\njobs:\n code_analysis:\n   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main\n"),
 			},
 			want:    "",
 			wantErr: true,
@@ -672,7 +847,7 @@ func TestRepository_createWorkflowFile(t *testing.T) {
 				DefaultBranch: "main",
 			},
 			args: args{
-				WorkflowFile: "../examples/codeql.yml",
+				WorkflowFile: []byte("name: CodeQL \non:\n  push:\n    branches: [ \"main\" ]\n  pull_request:\n    branches: [ \"main\" ]\n  workflow_dispatch:\n\njobs:\n code_analysis:\n   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main\n"),
 			},
 			want:    "",
 			wantErr: true,
@@ -685,13 +860,13 @@ func TestRepository_createWorkflowFile(t *testing.T) {
 				Name:          tt.fields.Name,
 				DefaultBranch: tt.fields.DefaultBranch,
 			}
-			got, err := repo.createWorkflowFile(tt.args.WorkflowFile)
+			got, err := repo.commitWorkflowFile(tt.args.WorkflowFile)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Repository.createWorkflowFile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Repository.commitWorkflowFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("Repository.createWorkflowFile() = %v, want %v", got, tt.want)
+				t.Errorf("Repository.commitWorkflowFile() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -835,5 +1010,4 @@ func TestRepository_deleteBranch(t *testing.T) {
 		})
 	}
 }
-
 

--- a/examples/codeql-template.yml
+++ b/examples/codeql-template.yml
@@ -1,0 +1,11 @@
+name: CodeQL 
+on:
+  push:
+    branches: [ "{{ .DefaultBranch }}" ]
+  pull_request:
+    branches: [ "{{ .DefaultBranch }}" ]
+  workflow_dispatch:
+
+jobs:
+ code_analysis:
+   uses: advanced-security-demo/central-repo-test/.github/workflows/code_analysis.yml@main


### PR DESCRIPTION
## What does this PR do?

This PR introduces the `--template` or `-t` flag to generate a `codeql.yml` file based of a template. The current iteration is to dynamically generate a `codeql.yml` file based of a repo's default branch and keeps everything else in the template the same. 

The idea here is that many repos will have custom default branches but for a reusable workflow, everything else should be the same. This change will automatically generate a file based of the repo's default branch to ensure that codeql scans run on every push to the default branch and on every PR to the default branch.

I refactored the code a little so that we will now either read the codeql.yml file from disk and use that as the commit file or we will generate one from the template file depending on which flag was used. 

## What is a GIF to represent my feelings of this PR

![](https://media.giphy.com/media/l2YWs1NexTst9YmFG/giphy.gif)